### PR TITLE
Fix conversion of degree to radian angle

### DIFF
--- a/chart/src/commonMain/kotlin/com/aay/compose/donutChart/component/PiePedigreeChart.kt
+++ b/chart/src/commonMain/kotlin/com/aay/compose/donutChart/component/PiePedigreeChart.kt
@@ -17,6 +17,7 @@ import com.aay.compose.donutChart.model.ChartTypes
 import kotlin.math.cos
 import kotlin.math.roundToInt
 import kotlin.math.sin
+import kotlin.math.PI
 
 @OptIn(ExperimentalTextApi::class)
 internal fun DrawScope.drawPedigreeChart(
@@ -132,7 +133,7 @@ internal fun DrawScope.drawPedigreeChart(
 }
 
 private val Float.degreeToAngle
-    get() = (this * (22/7) / 180f)
+    get() = this * PI / 180f
 
 private fun calculateAngle(dataLength: Float, totalLength: Float, progress: Float): Float =
     -360F * dataLength * progress / totalLength


### PR DESCRIPTION
I fixed this problem
https://github.com/TheChance101/AAY-chart/issues/99

Problem:
instead of using the correct PI in the calculation, (22/7) is used for PI. This causes the problem because (22/7) is not the same as standard PI(Koltin PI).