### PR TITLE
Add Feature to Display Scores Beside Polygon Points in RadarChart

### DIFF
--- a/chart/src/commonMain/kotlin/com/aay/compose/radarChart/DrawPolygon.kt
+++ b/chart/src/commonMain/kotlin/com/aay/compose/radarChart/DrawPolygon.kt
@@ -14,7 +14,7 @@ internal fun DrawScope.drawPolygonShape(
     scalarValue: Double,
     center: Offset,
     scalarSteps: Int
-) {
+): List<Offset> {
     val polygonEndPoints =
         getPolygonShapeEndPoints(polygon.values, radius, scalarValue, center, scalarSteps)
     val path = Path().apply {
@@ -35,6 +35,8 @@ internal fun DrawScope.drawPolygonShape(
             alpha = polygon.style.fillColorAlpha
         )
     }
+
+    return polygonEndPoints
 }
 
 private fun Path.drawPolygon(polygonCorners: List<Offset>) {

--- a/chart/src/commonMain/kotlin/com/aay/compose/radarChart/DrawScores.kt
+++ b/chart/src/commonMain/kotlin/com/aay/compose/radarChart/DrawScores.kt
@@ -1,0 +1,42 @@
+package com.aay.compose.radarChart
+
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.graphics.drawscope.DrawScope
+import androidx.compose.ui.text.AnnotatedString
+import androidx.compose.ui.text.TextMeasurer
+import androidx.compose.ui.text.TextStyle
+import androidx.compose.ui.text.ExperimentalTextApi
+import androidx.compose.ui.text.drawText
+
+@OptIn(ExperimentalTextApi::class)
+internal fun DrawScope.drawScores(
+    points: List<Offset>,
+    values: List<Double>,
+    textStyle: TextStyle,
+    textMeasurer: TextMeasurer,
+    unit: String
+) {
+    val centerY = size.height / 2f
+
+    points.forEachIndexed { index, point: Offset ->
+        val score = "${values[index]} $unit"
+        val textOffset = 15.toDp().toPx()
+        val isBottomHalf = point.y > centerY
+        val textLayoutResult = textMeasurer.measure(
+            text = AnnotatedString(score),
+            style = textStyle
+        )
+        val textPosition = Offset(
+            x = point.x - textLayoutResult.size.width / 2f,
+            y = if (isBottomHalf) point.y + textOffset
+            else point.y - textLayoutResult.size.height - textOffset
+        )
+
+        drawText(
+            textMeasurer = textMeasurer,
+            text = score,
+            style = textStyle,
+            topLeft = textPosition
+        )
+    }
+}

--- a/chart/src/commonMain/kotlin/com/aay/compose/radarChart/RadarChart.kt
+++ b/chart/src/commonMain/kotlin/com/aay/compose/radarChart/RadarChart.kt
@@ -22,6 +22,7 @@ import com.aay.compose.radarChart.model.Polygon
  * @param scalarValue Scalar value to determine the scale of the radar chart.
  * @param scalarValuesStyle TextStyle for configuring the appearance of scalar value labels.
  * @param polygons List of polygons to be displayed on the radar chart.
+ * @param showScores Flag to determine whether to display polygon scores (default is false).
  * @param modifier Modifier for configuring the layout and appearance of the radar chart.
  *
  * @see Polygon
@@ -37,6 +38,7 @@ fun RadarChart(
     scalarValue: Double,
     scalarValuesStyle: TextStyle,
     polygons: List<Polygon>,
+    showScores: Boolean = false,
     modifier: Modifier = Modifier
 ) {
 
@@ -55,15 +57,25 @@ fun RadarChart(
 
         drawRadarNet(netLinesStyle, radarChartConfig)
 
-        polygons.forEach {
-            drawPolygonShape(
+        polygons.forEach { polygon ->
+            val points = drawPolygonShape(
                 this,
-                it,
+                polygon,
                 radius,
                 scalarValue,
                 Offset(size.width / 2, size.height / 2),
                 scalarSteps
             )
+
+            if (showScores) {
+                drawScores(
+                    points,
+                    polygon.values,
+                    scalarValuesStyle.copy(fontSize = scalarValuesStyle.fontSize * 0.8f),
+                    textMeasurer,
+                    polygons[0].unit
+                )
+            }
         }
 
         drawAxisData(


### PR DESCRIPTION
Pull Request: Add Feature to Display Scores Beside Polygon Points in RadarChart
This PR introduces a new feature to enhance the RadarChart by displaying scores beside the polygon points.

Scores are rendered above the points in the upper half of the graph and below the points in the lower half, depending on their position.
The visibility of the scores can be controlled through a boolean variable named showScores, allowing users to toggle this feature as needed.
This enhancement aims to improve the visual clarity of the chart by presenting scores more effectively. This feature arises from a personal need to better visualize the data, particularly in an educational context where scores range from 1 to 10. I believe this addition will be beneficial for better visualizing data in such settings.

In my opinion, this PR makes the most sense when paired with the second PR (submitted separately), which allows scalar values to be deactivated. An alternative option would be to automatically disable scalar values when scores are enabled, for a cleaner visual presentation.

A potential improvement could involve calculating the score positions dynamically to avoid overlap when two scores occupy the same space; however, this approach would add considerable complexity to the code.

I remain attentive to any suggestions, questions, or comments you may have!