### PR TITLE
Add toggle for scalar values visibility in RadarChart

### DIFF
--- a/chart/src/commonMain/kotlin/com/aay/compose/radarChart/DrawAxisData.kt
+++ b/chart/src/commonMain/kotlin/com/aay/compose/radarChart/DrawAxisData.kt
@@ -18,7 +18,8 @@ internal fun DrawScope.drawAxisData(
     radarLabels: List<String>,
     scalarValue: Double,
     scalarSteps: Int,
-    unit: String
+    unit: String,
+    showScalarValues: Boolean
 ) {
 
     val labelsEndPoints = radarChartConfig.labelsPoints
@@ -31,17 +32,20 @@ internal fun DrawScope.drawAxisData(
     val labelHeight = textMeasurer.measure(AnnotatedString("M")).size.height
 
 
-    for (step in 0 until scalarSteps) {
-        drawText(
-            textMeasurer = textMeasurer,
-            text = (scalarStep * step).toString() + " " + unit,
-            style = scalarValuesStyle,
-            topLeft = Offset(
-                nextStartPoints[step].x + 5.toDp().toPx(),
-                nextStartPoints[step].y - textVerticalOffset
+    if (showScalarValues) {
+        for (step in 0 until scalarSteps) {
+            drawText(
+                textMeasurer = textMeasurer,
+                text = (scalarStep * step).toString() + " " + unit,
+                style = scalarValuesStyle,
+                topLeft = Offset(
+                    nextStartPoints[step].x + 5.toDp().toPx(),
+                    nextStartPoints[step].y - textVerticalOffset
+                )
             )
-        )
+        }
     }
+
 
     for (line in labelsEndPoints.indices) {
         drawText(

--- a/chart/src/commonMain/kotlin/com/aay/compose/radarChart/RadarChart.kt
+++ b/chart/src/commonMain/kotlin/com/aay/compose/radarChart/RadarChart.kt
@@ -22,6 +22,7 @@ import com.aay.compose.radarChart.model.Polygon
  * @param scalarValue Scalar value to determine the scale of the radar chart.
  * @param scalarValuesStyle TextStyle for configuring the appearance of scalar value labels.
  * @param polygons List of polygons to be displayed on the radar chart.
+ * @param showScalarValues Flag to determine whether to display scalar values on the radar chart (default is true).
  * @param modifier Modifier for configuring the layout and appearance of the radar chart.
  *
  * @see Polygon
@@ -37,6 +38,7 @@ fun RadarChart(
     scalarValue: Double,
     scalarValuesStyle: TextStyle,
     polygons: List<Polygon>,
+    showScalarValues: Boolean = true,
     modifier: Modifier = Modifier
 ) {
 
@@ -74,7 +76,8 @@ fun RadarChart(
             radarLabels,
             scalarValue,
             scalarSteps,
-            polygons[0].unit
+            polygons[0].unit,
+            showScalarValues
         )
 
     }


### PR DESCRIPTION
Pull Request: Add Toggle for Scalar Values Visibility in RadarChart
This PR introduces a feature to control the visibility of scalar values in the RadarChart.

Adds a boolean variable showScalarValues to toggle the display of scalar values, providing a cleaner and more flexible visualization option.
When deactivated, scalar values are hidden, which enhances the readability of the chart, especially when used alongside score displays.
This feature was motivated by a need to improve the clarity of the chart in educational contexts where scores between 1 and 10 are frequently displayed, reducing visual clutter and focusing on essential data.

In combination with the other PR for displaying scores beside polygon points, this update reduce visual clutter. 

I remain attentive to any suggestions, questions, or comments you may have!